### PR TITLE
curl > wget

### DIFF
--- a/packer
+++ b/packer
@@ -89,15 +89,10 @@ isignored() {
   [[ " ${ignoredpackages[@]} " =~ " $1 " ]]
 }
 
-# Encodes urls properly
-urlencode() {
-sed 's/%/%25/g;s/ /%20/g;s/ /%09/g;s/!/%21/g;s/"/%22/g;s/#/%23/g;s/\$/%24/g;s/\&/%26/g;s/'\''/%27/g;s/(/%28/g;s/)/%29/g;s/\*/%2a/g;s/+/%2b/g;s/,/%2c/g;s/-/%2d/g;s/\./%2e/g;s/\//%2f/g;s/:/%3a/g;s/;/%3b/g;s//%3e/g;s/?/%3f/g;s/@/%40/g;s/\[/%5b/g;s/\\/%5c/g;s/\]/%5d/g;s/\^/%5e/g;s/_/%5f/g;s/`/%60/g;s/{/%7b/g;s/|/%7c/g;s/}/%7d/g;s/~/%7e/g' <<<"$1"
-}
-
 # Tests whether $1 exists on the aur
 existsinaur() {
   if ! [[ -f "$tmpdir/$1.info" ]]; then
-    wget -q "http://aur.archlinux.org/rpc.php?type=info&arg=$(urlencode "$1")" -O "$tmpdir/$1.info"
+    curl -Gs --data-urlencode "arg=$1" "http://aur.archlinux.org/rpc.php?type=info" > "$tmpdir/$1.info"
   fi
   ! grep -Fq ':"No result found"' "$tmpdir/$1.info"
 }
@@ -126,7 +121,7 @@ existsinlocal() {
 # Scrapes the aur deps from PKGBUILDS and puts in globally available dependencies array
 scrapeaurdeps() {
   if ! [[ -f "$tmpdir/$1.PKGBUILD" ]]; then
-    wget -q "http://aur.archlinux.org/packages/$1/$1/PKGBUILD" -O "$tmpdir/$1.PKGBUILD"
+    curl -s "http://aur.archlinux.org/packages/$1/$1/PKGBUILD" > "$tmpdir/$1.PKGBUILD"
   fi
   . "$tmpdir/$1.PKGBUILD"
   IFS=$'\n'
@@ -239,7 +234,7 @@ aurbar() {
 # Checks if package is newer on aur ($1 is package name, $2 is local version)
 aurversionisnewer() {
   if ! [[ -f "$tmpdir/$1.info" ]]; then
-    wget -q "http://aur.archlinux.org/rpc.php?type=info&arg=$(urlencode "$1")" -O "$tmpdir/$1.info"
+    curl -Gs --data-urlencode "arg=$1" "http://aur.archlinux.org/rpc.php?type=info" > "$tmpdir/$1.info"
   fi
   unset aurversion
   if ! grep -Fq ':"No result found"' "$tmpdir/$1.info"; then
@@ -256,7 +251,7 @@ aurversionisnewer() {
 
 isoutofdate() {
   if ! [[ -f "$tmpdir/$1.info" ]]; then
-    wget -q "http://aur.archlinux.org/rpc.php?type=info&arg=$(urlencode "$1")" -O "$tmpdir/$1.info"
+    curl -Gs --data-urlencode "arg=$1" "http://aur.archlinux.org/rpc.php?type=info" > "$tmpdir/$1.info"
   fi
   grep -qF '"OutOfDate":"1"}}' "$tmpdir/$1.info"
 }
@@ -273,7 +268,7 @@ aurinstall() {
     [[ -d $dir ]] && rm -rf $dir
     mkdir -p "$dir"
     cd "$dir"
-    wget "http://aur.archlinux.org/packages/$1/$1.tar.gz"
+    curl -q "http://aur.archlinux.org/packages/$1/$1.tar.gz" > "$1.tar.gz"
     tar xf "$1.tar.gz"
     cd "$1"
   fi
@@ -529,7 +524,7 @@ if [[ $option = update ]]; then
       else
         if existsinaur "$pkg"; then
           unset _darcstrunk _cvsroot _gitroot _svntrunk _bzrtrunk _hgroot
-          wget -q "http://aur.archlinux.org/packages/$pkg/$pkg/PKGBUILD" -O "$tmpdir/$pkg.PKGBUILD"
+          curl -s "http://aur.archlinux.org/packages/$pkg/$pkg/PKGBUILD" > "$tmpdir/$pkg.PKGBUILD"
           [[ $? -eq 0 ]] || continue
           . "$tmpdir/$pkg.PKGBUILD"
           if [[ "$(LC_ALL=C vercmp "$pkgver" "$ver")" -gt 0 ]]; then
@@ -582,7 +577,7 @@ if [[ $option = download ]]; then
   done
 
   for package in "${pkglist[@]}"; do
-    wget "http://aur.archlinux.org/packages/$package/$package.tar.gz" -O "$package.tar.gz"
+    curl -s "http://aur.archlinux.org/packages/$package/$package.tar.gz" > "$package.tar.gz"
     tar xf "$package.tar.gz" 
   done
 fi
@@ -626,10 +621,10 @@ if [[ $option = search || $option = searchinstall ]]; then
   # Aur searching and tmpfile preparation
   if  [[ ${#packageargs[@]} -eq 1 ]]; then
     # Fill up the arrays with package information from dump file
-    wget -q "http://aur.archlinux.org/rpc.php?type=search&arg=$(urlencode "$packageargs")" -O- | sed -e 's/","/"\n"/g' -e 's/\\//g' > "$tmpdir/$packageargs.search" 
+    curl -Gs --data-urlencode "arg=$packageargs" "http://aur.archlinux.org/rpc.php?type=search" | sed -e 's/","/"\n"/g' -e 's/\\//g' > "$tmpdir/$packageargs.search" 
     parsefile="$tmpdir/$packageargs.search"
   else
-    wget -q "http://aur.archlinux.org/rpc.php?type=search&arg=$(urlencode "$packageargs")" -O- | sed -e 's/{/\n{/g' -e 's/\\//g' > "$tmpdir/$packageargs.search-0"
+    curl -Gs --data-urlencode "arg=$packageargs" "http://aur.archlinux.org/rpc.php?type=search" | sed -e 's/{/\n{/g' -e 's/\\//g' > "$tmpdir/$packageargs.search-0"
     for ((i=1 ; i<${#packageargs[@]} ; i++)); do
       grep -e "\"Name\":\".*${packageargs[$i]}.*\",\"Version" -e "\"Description\":\".*${packageargs[$i]}.*\",\"LocationID" "${tmpdir}/$packageargs.search-$((i-1))" > "$tmpdir/$packageargs.search-$i"
     done
@@ -716,7 +711,7 @@ if [[ $option = info ]]; then
       $outputpacman -Si -- "$package"
       exit
     else # Check to see if it is in the aur
-      wget -q "http://aur.archlinux.org/packages/$package/$package/PKGBUILD" -O "$tmpdir/$package.PKGBUILD"
+      curl -s "http://aur.archlinux.org/packages/$package/$package/PKGBUILD" > "$tmpdir/$package.PKGBUILD"
       [[ $? -eq 0 ]] || err "${COLOR7}error:${ENDCOLOR} package '$package' was not found"
       . "$tmpdir/$package.PKGBUILD"
 


### PR DESCRIPTION
In case you're interested, replacing wget with curl means that you can throw out the url_encode function, since curl has its own.
