### PR TITLE
Allow reviewing installation files with $PAGER

### DIFF
--- a/packer
+++ b/packer
@@ -17,14 +17,14 @@ PKGURL="https://aur.archlinux.org/packages"
 pacman="$(type -p pacman)"
 outputpacman="$(type -p pacman-color)"
 if [[ $outputpacman && ! $COLOR = "NO" ]]; then
-  COLOR1='\e[1;39m'
-  COLOR2='\e[1;32m'
-  COLOR3='\e[1;35m'
-  COLOR4='\e[1;36m'
-  COLOR5='\e[1;34m'
-  COLOR6='\e[1;33m'
-  COLOR7='\e[1;31m'
-  ENDCOLOR='\e[0m'
+  COLOR1="`echo -ne '\e[1;39m'`"
+  COLOR2="`echo -ne '\e[1;32m'`"
+  COLOR3="`echo -ne '\e[1;35m'`"
+  COLOR4="`echo -ne '\e[1;36m'`"
+  COLOR5="`echo -ne '\e[1;34m'`"
+  COLOR6="`echo -ne '\e[1;33m'`"
+  COLOR7="`echo -ne '\e[1;31m'`"
+  ENDCOLOR="`echo -ne '\e[0m'`"
 else
   outputpacman="$pacman"
 fi
@@ -241,6 +241,31 @@ isoutofdate() {
   grep -qF '"OutOfDate":"1"}}' "$tmpdir/$1.info"
 }
 
+# prompt_edit <file> [<package name for display at prompt>]
+prompt_edit() {
+  while ! [[ $noconfirm || $noedit ]]; do
+    EDITOR="${EDITOR:-vi}"
+    read -p "${COLOR6}Edit${2:+ $2} $1 with $EDITOR? [Y/n/c]${ENDCOLOR} " -n 1
+    echo
+    case "${REPLY:-Y}" in
+      'c')
+        read -p "Change \$EDITOR? [$EDITOR] "
+        REPLY="${REPLY:-$EDITOR}"
+        if eval "'$REPLY' '$1'"; then
+          EDITOR="$REPLY"
+        fi
+        ;;
+      'Y'|'y')
+        eval "'$EDITOR' '$1'"
+        ;;
+      'n')
+        # ok, we're done
+        return
+        ;;
+    esac
+  done
+}
+
 # Installs packages from aur ($1 is package, $2 is dependency or explicit)
 aurinstall() {
   dir="${TMPDIR:-/tmp}/packerbuild-$UID/$1"
@@ -260,16 +285,7 @@ aurinstall() {
 
   # Allow user to edit PKGBUILD
   if [[ -f PKGBUILD ]]; then
-    if ! [[ $noconfirm || $noedit ]]; then
-      echo -en "${COLOR6}Edit $1 PKGBUILD with \$EDITOR? [Y/n]${ENDCOLOR} "
-      read -n 1 answer
-      echo
-      case "$answer" in
-        'Y'|'y'|'')
-          eval ${EDITOR:-vi} PKGBUILD
-          ;;
-      esac
-    fi
+    prompt_edit PKGBUILD $1
   else
     err "No PKGBUILD found in directory."
   fi
@@ -278,15 +294,13 @@ aurinstall() {
   unset install
   . PKGBUILD
   if [[ $install ]]; then
-    if ! [[ $noconfirm || $noedit ]]; then
-      echo -en "${COLOR6}Edit $install with \$EDITOR? [Y/n]${ENDCOLOR} "
-      read -n 1 answer
-      echo
-      case "$answer" in
-        'Y'|'y'|'')
-          eval ${EDITOR:-vi} "$install"
-          ;;
-      esac 
+    prompt_edit $install
+  fi
+
+  # Prompt to proceed if files could have been reviewed
+  if ! [[ $noedit ]]; then
+    if ! proceed "Proceed with installation?" Y; then
+      exit
     fi
   fi
 
@@ -340,11 +354,8 @@ installhandling() {
   # Check if any aur target packages are ignored
   for package in "${aurpackages[@]}"; do
     if isignored "$package"; then
-      echo -ne "${COLOR5}:: ${COLOR1}$package is in IgnorePkg/IgnoreGroup. Install anyway?${ENDCOLOR} [Y/n] "
-      if ! [[ $noconfirm ]]; then
-        if ! proceed; then
-          continue
-        fi
+      if ! proceed "${COLOR5}:: ${COLOR1}$package is in IgnorePkg/IgnoreGroup.${ENDCOLOR}  Install anyway?" Y; then
+        continue
       fi
     fi
     aurtargets+=("$package")
@@ -353,13 +364,10 @@ installhandling() {
   # Check if any aur dependencies are ignored
   for package in "${aurdepends[@]}"; do
     if isignored "$package"; then
-      echo -ne "${COLOR5}:: ${COLOR1}$package is in IgnorePkg/IgnoreGroup. Install anyway?${ENDCOLOR} [Y/n] "
-      if ! [[ $noconfirm ]]; then
-        if ! proceed; then
-          echo "Unresolved dependency \`$package'"
-          unset aurtargets
-          break
-        fi
+      if ! proceed "${COLOR5}:: ${COLOR1}$package is in IgnorePkg/IgnoreGroup.${ENDCOLOR}  Install anyway?" N; then
+        echo "Unresolved dependency \`$package'"
+        unset aurtargets
+        break
       fi
     fi
   done
@@ -404,13 +412,11 @@ installhandling() {
       pacmandepends=( $(printf "%s\n" "${pacmandepends[@]}" | sort -u) )
       echo -e "${COLOR6}Pacman Targets (${#pacmandepends[@]}):${ENDCOLOR} ${pacmandepends[@]}"
     fi
+    echo
 
     # Prompt to proceed
-    echo -en "\nProceed with installation? [Y/n] "
-    if ! [[ $noconfirm ]]; then
-      proceed || exit
-    else
-      echo
+    if ! proceed "Proceed with installation?" Y; then
+      exit
     fi
 
     # Install pacman dependencies
@@ -437,13 +443,19 @@ installhandling() {
   fi
 }
 
-# proceed with installation prompt
+# proceed <prompt> [<default/noconfirm answer>]
 proceed() {
-  read -r
-  case "$REPLY" in
-    'Y'|'y'|'') return 0 ;;
-    *)       return 1 ;;
+  case "$2" in
+    'Y') q='Y/n' ;;
+    'n') q='y/N' ;;
+    *)   q='y/n' ;;
   esac
+  while [[ $noconfirm && REPLY=${2:-n} ]] || read -p "$1 [$q] " -r; do
+    case "${REPLY:-$2}" in
+      'Y'|'y') return 0 ;;
+      'n')     return 1 ;;
+    esac
+  done
 }
 
 # process busy loop


### PR DESCRIPTION
This patch allows reviewing the installation files with a pager (by calling e.g. EDITOR=cat packer ...) with the possibility to switch to an $EDITOR on demand.
