### PR TITLE
aurinstall(): improve installation handling with package signatures / $PKGDEST

### DIFF
--- a/packer
+++ b/packer
@@ -299,17 +299,9 @@ aurinstall() {
 
   [[ $? -ne 0 ]] && echo "The build failed." && return 1
   if  [[ $2 = dependency ]]; then
-    if [[ $PKGDEST ]]; then
-      runasroot $outputpacman ${PACOPTS[@]} --asdeps -U "$PKGDEST"/$pkgname-*.pkg.tar.*
-    else
-      runasroot $outputpacman ${PACOPTS[@]} --asdeps -U $pkgname-*.pkg.tar.*
-    fi
+    runasroot $outputpacman ${PACOPTS[@]} --asdeps -U $pkgname-*$PKGEXT
   elif [[ $2 = explicit ]]; then
-    if [[ $PKGDEST ]]; then
-      runasroot $outputpacman ${PACOPTS[@]} -U "$PKGDEST"/$pkgname-*.pkg.tar.*
-    else
-      runasroot $outputpacman ${PACOPTS[@]} -U $pkgname-*.pkg.tar.*
-    fi
+    runasroot $outputpacman ${PACOPTS[@]} -U $pkgname-*$PKGEXT
   fi
 }
 


### PR DESCRIPTION
First, extension globbing is removed. Package signing creates a
$PKGEXT.sig file which breaks the pacman -U call. makepkg.conf is
sourced anyways so we can just use $PKGEXT from there.

Second, don't use PKGDEST; pkgver globbing returns invalid results for
pacman -U if PKGDEST contains more than one version of a package.
makepkg creates a symlink in the build directory, so just use that.

Signed-off-by: Jakob Gruber jakob.gruber@gmail.com
