### PR TITLE
Expac patch

### DIFF
--- a/packer
+++ b/packer
@@ -67,7 +67,7 @@ runasroot() {
   else
     echo -n "root "
     # Hack: need to echo to make sure all of the args get in the single set of quotes
-    su root -c "$(echo $@)"
+    su -c "$(printf '%q ' "$@")"
   fi
 }
 

--- a/packer.8
+++ b/packer.8
@@ -208,6 +208,8 @@ IgnorePkg
 Packer output will be colorized unless the environmental variable COLOR is set to `NO'.
 .sp
 To manually edit files, packer uses the EDITOR variable\&. If EDITOR is not set then the default editor is vi\&.
+.sp
+Packages are built in the TMPDIR path\&. If the TMPDIR variable is not set then the default path is /tmp
 .SH "SEE ALSO"
 .sp
 \fBpacman\fR(8)


### PR DESCRIPTION
Many pacman -Si/Ss/Q/Qs calls have been replaced with expac versions.  This is slightly faster, slightly shorter, more readable and much more stable.

Also made color work with stock pacman and proper wrapping of long descriptions.
