### PR TITLE
Added a "--repo <file>" option

### DIFF
--- a/packer
+++ b/packer
@@ -298,8 +298,8 @@ aurinstall() {
 
   # Install
   if [[ $repofile ]]; then
+    cp -t "$(dirname "$repofile")" $pkgname-*$PKGEXT
     repo-add "$repofile" $pkgname-*$PKGEXT
-    cp $pkgname-*$PKGEXT "$(dirname "$repofile")"
   elif  [[ $2 = dependency ]]; then
     runasroot pacman ${PACOPTS[@]} --asdeps -U $pkgname-*$PKGEXT
   elif [[ $2 = explicit ]]; then


### PR DESCRIPTION
Instead of installing built packages as foreign packages, this flag lets you update a local repository.

Pacman's support for AUR packages isn't particularly spectacular, so this flag lets you use packer to automatically build, install and update a local repository that you can share, or just include in pacman.conf.

For example, you can put the following into your `pacman.conf`:

```
[aur]
Server = file:///home/ogier/aur
```

then run

```
mkdir ~/aur
packer -S --repo ~/aur/aur.db.tar.gz packer dropbox ... whatever
```

And now you can `pacman -S` anything you have added to this local repo, just like it were official. To keep things up to date on the machine with your AUR repo, you should really run three commands:

```
packer -Syu # to update build dependencies
packer -Syu --repo whatever.db.tar.gz # to rebuild anything in your AUR repo
packer -Syu # to get the stuff you rebuilt
```

Clearly most people don't want to do this on every update, so the flag isn't for everyone, but it's a dead simple way to maintain a repo with prebuilt AUR packages, something I was doing manually before.
