### PR TITLE
make sure that we always untar aur packages to a predictable directory

### DIFF
--- a/packer
+++ b/packer
@@ -283,7 +283,8 @@ aurinstall() {
     mkdir -p "$dir"
     cd "$dir"
     curl -Lfs "$(pkglink $1)" > "$1.tar.gz"
-    tar xf "$1.tar.gz"
+    mkdir "$1"
+    tar xf "$1.tar.gz" -C "$1" --strip-components=1
     cd "$1"
 
     # customizepkg


### PR DESCRIPTION
I ran into a package whose top-level directory in the tar wasn't the same as the name of the package. This ensures that we'll always be untarring into the "correct" directory.
