### PR TITLE
More explicit globbing taking version and relase into account to avoid f...

### DIFF
--- a/packer
+++ b/packer
@@ -324,9 +324,9 @@ aurinstall() {
 
   [[ $? -ne 0 ]] && echo "The build failed." && return 1
   if  [[ $2 = dependency ]]; then
-    runasroot $PACMAN ${PACOPTS[@]} --asdeps -U $pkgname-*$PKGEXT
+    runasroot $PACMAN ${PACOPTS[@]} --asdeps -U $pkgname-$pkgver-$pkgrel*$PKGEXT
   elif [[ $2 = explicit ]]; then
-    runasroot $PACMAN ${PACOPTS[@]} -U $pkgname-*$PKGEXT
+    runasroot $PACMAN ${PACOPTS[@]} -U $pkgname-$pkgver-$pkgrel*$PKGEXT
   fi
 }
 


### PR DESCRIPTION
...requent warning/error: duplicate target of xyz.
Based on patch posted to https://bbs.archlinux.org/viewtopic.php?pid=907691#p907691

This helps to avoid errors like:

```
error: 'i3-git-20120919-1-x86_64.pkg.tar.xz': duplicate target
```
