### PR TITLE
Add --ignorearch option

### DIFF
--- a/packer
+++ b/packer
@@ -59,7 +59,7 @@ usage() {
   echo '    -Ss|-Ssq    - searches for package'
   echo '    -Si         - outputs info for package'
   echo '    -G          - download and extract aur tarball only'
-  echo '    -A			- when using makepkg, ignores missing or incomplete arch field in the build script'
+  echo '    -A          - when using makepkg, ignores missing or incomplete arch field in the build script'
   echo
   echo '    --quiet     - only output package name for searches'
   echo '    --ignore    - takes a comma-separated list of packages to ignore'

--- a/packer
+++ b/packer
@@ -59,6 +59,7 @@ usage() {
   echo '    -Ss|-Ssq    - searches for package'
   echo '    -Si         - outputs info for package'
   echo '    -G          - download and extract aur tarball only'
+  echo '    -A			- when using makepkg, ignores missing or incomplete arch field in the build script'
   echo
   echo '    --quiet     - only output package name for searches'
   echo '    --ignore    - takes a comma-separated list of packages to ignore'
@@ -66,6 +67,7 @@ usage() {
   echo '    --noedit    - do not prompt to edit files'
   echo '    --auronly   - only do actions for aur'
   echo '    --devel     - update devel packages during -Su'
+  echo '    --ignorearch- when using makepkg, ignores missing or incomplete arch field in the build script'
   echo '    --skipinteg - when using makepkg, do not check md5s'
   echo '    --preview   - edit pkgbuild before sourcing'
   echo '    -h          - outputs this message'
@@ -475,6 +477,7 @@ while [[ $1 ]]; do
     '-Si') option=info ;;
     -S*u*) option=update ; pacmanarg="$1" ;;
     '-G') option=download ;;
+    '-A') MAKEPKGOPTS="--ignorearch" ;;
     '-h'|'--help') usage ;;
     '--quiet') quiet='1' ;;
     '--ignore') ignorearg="$2" ; PACOPTS+=("--ignore" "$2") ; shift ;;
@@ -482,6 +485,7 @@ while [[ $1 ]]; do
     '--noedit') noedit='1' ;;
     '--auronly') auronly='1' ;;
     '--devel') devel='1' ;;
+    '--ignorearch') MAKEPKGOPTS="--ignorearch" ;;
     '--skipinteg') MAKEPKGOPTS="--skipinteg" ;;
     '--preview') preview='1' ;;
     '--') shift ; packageargs+=("$@") ; break ;;


### PR DESCRIPTION
I added the --ignorearch makepkg option to packer. It is really useful in particular context, especially when using packer on Archlinux ARM.
