### PR TITLE
"packer symbol" shows duplicate number

### DIFF
--- a/packer
+++ b/packer
@@ -615,7 +615,7 @@ if [[ $option = search || $option = searchinstall ]]; then
     if [[ $option = search ]]; then
       echo -e "$results" | fmt -"$_WIDTH" -s
     else  # interactive
-      echo -e "$results" | fmt -"$_WIDTH" -s | nl -v 0 -w 1 -s ' ' -b 'p^[^ ]'
+      echo -e "$results" | nl -v 0 -w 1 -s ' ' -b 'p^[^ ]' | fmt -"$_WIDTH" -s 
     fi | sed '/^$/d'
     pacname=( $(pacman -Ssq -- "${packageargs[@]}") )
     pactotal="${#pacname[@]}"


### PR DESCRIPTION
When I do "packer symbol", it shows double 7. Therefore I can't type 7 to choose ttf-symbola because it will install libindicator instead. This is caused by executing packer in a small terminal window since packer do 'fmt' before 'nl'.

0 extra/gnome-icon-theme-symbolic 3.6.2-1 (gnome)
1 [已安装]
      GNOME icon theme, symbolic icons
2 extra/qrencode 3.4.1-1
      C library for encoding data in a QR Code symbol.
3 community/ginac 1.6.2-2
      C++ library for symbolic calculations
4 community/perl-devel-symdump 2.08-4
      Perl symbol table access and dumping
5 community/python-sympy 0.7.2-1
      Symbolic manipulation package (Computer Algebra System), written in
      pure Python
6 community/python2-sympy 0.7.2-1
      Symbolic manipulation package (Computer Algebra System), written in
      pure Python
7 community/ttf-symbola 7.07-1 [已安装]
      Font for unicode symbols (part of Unicode Fonts for Ancient Scripts).
7 aur/libindicator 12.10.1-1 (301)
    Libary with a set of symbols and convience functions that all indicators
    would like to use (GTK+ 2 library)
8 aur/latex-xft-fonts 0.1-1 (139)
    TTF Fonts required to display math symbols in equations in LyX.
....
