### PR TITLE
Changed  warning message to match pacman's warning message

### DIFF
--- a/packer
+++ b/packer
@@ -613,7 +613,7 @@ if [[ $option = update ]]; then
   # Check and output ignored package update info
   for package in "${checkignores[@]}"; do
     if aurversionisnewer "${package%% *}" "${package##* }"; then
-      echo -e "${COLOR6}warning:${ENDCOLOR} $package: ignoring package upgrade (${package##* } => $aurversion)"
+      echo -e "${COLOR6}warning:${ENDCOLOR} ${package%% *}: ignoring package upgrade (${package##* } => $aurversion)"
     fi
   done
 


### PR DESCRIPTION
Changed warning message when package is on IgnorePkg and there's an upgrade available.

Before:

warning: phpstorm-eap 131.235-1: ignoring package upgrade (131.235-1 => 131.332-1)

After:

warning: phpstorm-eap: ignoring package upgrade (131.235-1 => 131.332-1)

This way we mimic the original pacman's warning message:

warning: nginx: ignoring package upgrade (1.2.9-1 => 1.4.2-4)
