### PR TITLE
ctrl-c needs to exit with non-zero exit code.

### DIFF
--- a/packer
+++ b/packer
@@ -43,7 +43,7 @@ _WIDTH="$(stty size | cut -d ' ' -f 2)"
 trap ctrlc INT
 ctrlc() {
   echo
-  exit
+  exit 1
 }
 
 err() {


### PR DESCRIPTION
When started like "packer -Syu && shutdown -h now" and later while downloading some aur package if  I decided to do "packer -Syu --noconfirm && shutdown -h now" and go to sleep, pressing ctrl-c shuts down the computer because packer return 0.
