### PR TITLE
install packages supplied to -Su. Closes #60.

### DIFF
--- a/packer
+++ b/packer
@@ -544,12 +544,6 @@ fi
 [[ $option ]] || option="searchinstall"
 [[ $option != "update" && -z $packageargs ]] && err "Must specify a package."
 
-# Install (-S) handling
-if [[ $option = install ]]; then
-  installhandling "${packageargs[@]}"
-  exit
-fi
-
 # Update (-Su) handling
 if [[ $option = update ]]; then
   getignoredpackages
@@ -631,6 +625,12 @@ if [[ $option = update ]]; then
     installhandling "${newpackages[@]}"
   fi
   echo " local database is up to date"
+fi
+
+# Install (-S) handling
+if [[ $option = install || $option = update ]]; then
+  installhandling "${packageargs[@]}"
+  exit
 fi
 
 # Download (-G) handling


### PR DESCRIPTION
I moved the code for installation after the code for updating to allow supplying packages to a -Su command. That is, it is now possible to install packages by issuing a command such as `packer -Syu <packages>`.This is consistent with pacman behavior.
