### PR TITLE
Fix file path with epochs

### DIFF
--- a/packer
+++ b/packer
@@ -336,7 +336,7 @@ aurinstall() {
   [[ $? -ne 0 ]] && echo "The build failed." && return 1
   pkgtarfiles=""
   for i in "${pkgname[@]}"; do
-    pkgtarfiles="$pkgtarfiles $i-$pkgver-$pkgrel*$PKGEXT"
+    pkgtarfiles="$pkgtarfiles $i*$PKGEXT"
   done
   if  [[ $2 = dependency ]]; then
     runasroot $PACMAN ${PACOPTS[@]} --asdeps -U $pkgtarfiles


### PR DESCRIPTION
It might be better to actually handle the full file path including all possible options that makepkg throws in. However, this simple patch allows packages with epochs to actually build and install. Please fix this ASAP...
