### PR TITLE
Update packer.8

### DIFF
--- a/packer.8
+++ b/packer.8
@@ -91,7 +91,7 @@ Update development packages\&. (cvs, git\&...)
 .PP
 \fB\-\-skipinteg\fR
 .RS 4
-Skip the integrity check by ignoring AUR package MD5 sums\&.
+Skip the integrity check by ignoring AUR package SHA sums\&.
 .RE
 .PP
 \fB\-\-preview\fR


### PR DESCRIPTION
MD5 is no longer in use, SHA-256 or higher is the default. The manual should also reflect this.