### PR TITLE
Add an option to clone package repo instead of downloading a tarball

### DIFF
--- a/packer
+++ b/packer
@@ -60,6 +60,7 @@ usage() {
   echo '    -Ss|-Ssq     - searches for package'
   echo '    -Si          - outputs info for package'
   echo '    -G           - download and extract aur tarball only'
+  echo '    -C           - clone/pull the package aur git repository'
   echo
   echo '    --quiet      - only output package name for searches'
   echo '    --ignore     - takes a comma-separated list of packages to ignore'
@@ -522,6 +523,7 @@ while [[ $1 ]]; do
     '-Si') option=info ;;
     -S*u*) option=update ; pacmanarg="$1" ;;
     '-G') option=download ;;
+    '-C') option=git ;;
     '-h'|'--help') usage ;;
     '--quiet') quiet='1' ;;
     '--ignore') ignorearg="$2" ; PACOPTS+=("--ignore" "$2") ; shift ;;
@@ -652,6 +654,34 @@ if [[ $option = download ]]; then
     curl -Lfs "$(pkglink $package)" > "$package.tar.gz"
     mkdir "$package"
     tar xf "$package.tar.gz" -C "$package" --strip-components=1
+  done
+fi
+
+
+# Git clone/pull handling
+
+if [[ $option = git ]]; then
+  for package in "${packageargs[@]}"; do
+    if existsinaur "$package"; then
+      pkglist+=("$package")
+    else
+      err "Package \`$package' does not exist on aur."
+    fi
+  done
+
+  for package in "${pkglist[@]}"; do
+    clone_link="${PKGURL}/${package}.git"
+
+    # if a clone already exists, try to pull
+    # otherwise clone.
+    if [[ -d "$package/.git" ]]; then
+      cd "$package"
+      git pull "${clone_link}"
+      cd ..
+    else
+      # shallow clone
+      git clone --depth 1 "${clone_link}" "${package}"
+    fi
   done
 fi
 
@@ -802,3 +832,5 @@ if [[ $option = info ]]; then
     fi
   done
 fi
+
+#vim: ts=2 sw=2 et:

--- a/packer
+++ b/packer
@@ -832,5 +832,3 @@ if [[ $option = info ]]; then
     fi
   done
 fi
-
-#vim: ts=2 sw=2 et:

--- a/packer.8
+++ b/packer.8
@@ -53,6 +53,11 @@ Show information for a package\&.
 Download and extract AUR package tarballs, but don\(cqt install anything\&.
 .RE
 .PP
+\fB\-C\fR
+.RS 4
+Using git, clone or update the AUR package repositories, but don\(cqt install anything\&.
+.RE
+.PP
 \fB\-h\fR
 .RS 4
 Show packer usage\&.


### PR DESCRIPTION
Added a new option that works like `-G`, but except makes a (shallow) clone/pull of a package's AUR repository instead of downloading the snapshot tarball.

This allows users to easily update a locally cloned package, without having to remove the previous copy first and doesn't keep any tarball clutter around, like with `-G`.

Currently using the `-C` flag (for clone), but that and the documentation can certainly be changed if needed.
