### PR TITLE
Added option to specify an alternative installation root

### DIFF
--- a/packer
+++ b/packer
@@ -70,6 +70,7 @@ usage() {
   echo '    --devel      - update devel packages during -Su'
   echo '    --skipinteg  - when using makepkg, do not check md5s'
   echo '    --preview    - edit pkgbuild before sourcing'
+  echo '    --root       - takes a path to an alternative installation root'
   echo '    -h           - outputs this message'
   exit
 }
@@ -532,6 +533,7 @@ while [[ $1 ]]; do
     '--devel') devel='1' ;;
     '--skipinteg') MAKEPKGOPTS="--skipinteg" ;;
     '--preview') preview='1' ;;
+    '--root') installroot="$2" ; PACOPTS+=("--root" "$2") ; shift ;;
     '--') shift ; packageargs+=("$@") ; break ;;
     -*) echo "packer: Option \`$1' is not valid." ; exit 5 ;;
     *) packageargs+=("$1") ;;

--- a/packer.8
+++ b/packer.8
@@ -98,6 +98,14 @@ Skip the integrity check by ignoring AUR package MD5 sums\&.
 .RS 4
 Always offer to edit the pkgbuild before sourcing it.  To always force preview, 'alias packer="packer --preview"'
 .RE
+.PP
+\fB\-\-root\fR <\'path\'>
+.RS 4
+Installs packages to an alternative root path\& (see the documentation for \fB\-\-root\fR in the
+.SM
+.B "OPTIONS"
+section of \fBpacman\fR(8))\&.
+.RE
 .SH "INTERACTIVE MODE"
 .sp
 Use packer without any operations or options to use the interactive mode\&. Packer will show a numbered list of search results\&. To install a package, enter the corresponding number\&.


### PR DESCRIPTION
I've been using `systemd-nspawn`ed machines a fair amount lately, and it would be *hugely* helpful (for at least this narrow use case) to be able to build AUR packages on the host machine but install them onto the guest.  This PR adds the `--root` option, passing it through to the underlying sync and upgrade `pacman` commands.

Thanks in advance for considering the PR!